### PR TITLE
Multi value attribute

### DIFF
--- a/data/System/LdapNgPlugin.txt
+++ b/data/System/LdapNgPlugin.txt
@@ -25,6 +25,9 @@ Parameters:
    * =header=: header to prepend the output; default: '$dn'
    * =footer=: footer to appended to the output
    * =separator=: separator between database records; default: '$n'
+   * =multivaluejoiner=: string to be used when joining multiple-values; 
+     if =multivaluejoiner= is set, multiple attribute values are joined by this string.
+     Without this, only the first of multiple values is displayed. Example: ', '
    * =sort=: name of attributes to sort the output %RED%(this feature is currently disabled)%ENDCOLOR%
    * =reverse=: reverse the result set; possible values: on, off; default: off
    * =limit=: maximum number of records to return; default: 0 (unlimited)

--- a/data/System/LdapNgPlugin.txt
+++ b/data/System/LdapNgPlugin.txt
@@ -25,6 +25,9 @@ Parameters:
    * =header=: header to prepend the output; default: '$dn'
    * =footer=: footer to appended to the output
    * =separator=: separator between database records; default: '$n'
+   * =multivaluejoiner=: string to be used when joining multiple-values; default: ''
+     if =multivaluejoiner= is set to something other than empty string, multiple attribute values are joined by this string.
+     Without this, only the first of multiple values is displayed. Example: ', '
    * =sort=: name of attributes to sort the output %RED%(this feature is currently disabled)%ENDCOLOR%
    * =reverse=: reverse the result set; possible values: on, off; default: off
    * =limit=: maximum number of records to return; default: 0 (unlimited)

--- a/lib/Foswiki/Plugins/LdapNgPlugin/Core.pm
+++ b/lib/Foswiki/Plugins/LdapNgPlugin/Core.pm
@@ -177,7 +177,11 @@ sub handleLdap {
       if ($blobAttrs{$attr}) { 
         $data{$attr} = $ldap->cacheBlob($entry, $attr, $theRefresh);
       } else {
-        $data{$attr} = $ldap->fromLdapCharSet($entry->get_value($attr));
+	if (defined $params->{multivaluejoiner}) {
+	  $data{$attr} = $ldap->fromLdapCharSet( join($params->{multivaluejoiner}, $entry->get_value($attr)) );
+	} else {
+	  $data{$attr} = $ldap->fromLdapCharSet($entry->get_value($attr));
+        }
       }
     }
     push @results, expandVars($theFormat, %data);


### PR DESCRIPTION
When we migrated from TWiki to Foswiki we found that our LDAP powered tables were only showing one attribute value. With this patch you can configure it for each 

> %LDAP{...}%

table without changing the default Foswiki behavior. It would be nicer to configure it globally, but I don't know which mechanism would be the right one.
